### PR TITLE
Add filters for grades cmd (course ID and course name)

### DIFF
--- a/cmd/grades.go
+++ b/cmd/grades.go
@@ -10,8 +10,16 @@ var gradesCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(gradesCmd)
+
+	gradesCmd.Flags().StringArrayP("courseid", "i", []string{}, "Filter by course ID")
 }
 
 func grades(cmd *cobra.Command, args []string) {
-	c.ListGrades()
+	if len(args) > 0 {
+		c.ListGrades()
+	} else {
+		if courseId, err := cmd.Flags().GetStringArray("courseid"); err == nil {
+			c.ListGradesByCourseId(courseId)
+		}
+	}
 }

--- a/cmd/grades.go
+++ b/cmd/grades.go
@@ -12,14 +12,25 @@ func init() {
 	rootCmd.AddCommand(gradesCmd)
 
 	gradesCmd.Flags().StringArrayP("courseid", "i", []string{}, "Filter by course ID")
+	gradesCmd.Flags().StringArrayP("course", "n", []string{}, "Filter by course name")
 }
 
 func grades(cmd *cobra.Command, args []string) {
-	if len(args) > 0 {
+	courseIds, err := cmd.Flags().GetStringArray("courseid")
+	cobra.CheckErr(err)
+
+	courseNames, err := cmd.Flags().GetStringArray("course")
+	cobra.CheckErr(err)
+
+	if len(courseIds) > 0 {
+		c.ListGradesByCourseId(courseIds)
+	}
+
+	if len(courseNames) > 0 {
+		c.ListGradesByCourseName(courseNames)
+	}
+
+	if len(courseIds) == 0 && len(courseNames) == 0 {
 		c.ListGrades()
-	} else {
-		if courseId, err := cmd.Flags().GetStringArray("courseid"); err == nil {
-			c.ListGradesByCourseId(courseId)
-		}
 	}
 }

--- a/util/grades.go
+++ b/util/grades.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/patitolabs/gosuv2"
 	"github.com/spf13/cobra"
@@ -34,6 +35,28 @@ func (c *Client) ListGradesByCourseId(courseId []string) {
 			prettyPrintGradeCourse(grade)
 			fmt.Println()
 			found = true
+		}
+	}
+
+	if !found {
+		fmt.Println("No courses found.")
+		os.Exit(1)
+	}
+}
+
+func (c *Client) ListGradesByCourseName(courseName []string) {
+	suvGradesResponse, err := c.SuvClient.GetSuvGradesResponse()
+	cobra.CheckErr(err)
+
+	found := false
+	for _, grade := range suvGradesResponse.Courses {
+		for _, name := range courseName {
+			if strings.Contains(grade.Curso, name) {
+				prettyPrintGradeCourse(grade)
+				fmt.Println()
+				found = true
+				break
+			}
 		}
 	}
 

--- a/util/grades.go
+++ b/util/grades.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/patitolabs/gosuv2"
@@ -15,6 +16,30 @@ func (c *Client) ListGrades() {
 	for _, grade := range suvGradesResponse.Courses {
 		prettyPrintGradeCourse(grade)
 		fmt.Println()
+	}
+}
+
+func (c *Client) ListGradesByCourseId(courseId []string) {
+	suvGradesResponse, err := c.SuvClient.GetSuvGradesResponse()
+	cobra.CheckErr(err)
+
+	courseIdMap := make(map[string]struct{})
+	for _, id := range courseId {
+		courseIdMap[id] = struct{}{}
+	}
+
+	found := false
+	for _, grade := range suvGradesResponse.Courses {
+		if _, exists := courseIdMap[grade.IdCurso]; exists {
+			prettyPrintGradeCourse(grade)
+			fmt.Println()
+			found = true
+		}
+	}
+
+	if !found {
+		fmt.Println("No courses found.")
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
This PR introduces some basic filters for the `grades` command. Both are cobra string arrays, so they can be passed multiple times.

```shell
$ suvctl grades -i 3001 -i 3002 -i 3003
```

```shell
$ suvctl grades -n PLANEAMIENTO -n NUBE
```

As expected, if no arguments are passed, all the available grades will be printed